### PR TITLE
Crude renaming argparse to arg_parse (because OTP26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# argparse: command line parser for Erlang
+# arg_parse: command line parser for Erlang
 
 [![Build Status](https://github.com/max-au/argparse/actions/workflows/erlang.yml/badge.svg?branch=master)](https://github.com/max-au/argparse/actions) [![Hex.pm](https://img.shields.io/hexpm/v/argparse.svg)](https://hex.pm/packages/argparse) [![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/argparse)
 
@@ -121,7 +121,7 @@ format usage output and error messages.
 
 See example: [doc/examples/multi](https://github.com/max-au/argparse/tree/master/doc/examples/multi)
 
-This example contains two modules, multi_math.erl and multi_string.erl.
+This example contains two modules, multi\_math.erl and multi\_string.erl.
 
 Use ```rebar3 escriptize``` to build the application. Try various commands,
 e.g. ```./multi math cos 1.0```, or ```./multi string lexemes 1+2+3+4 -s +```
@@ -136,7 +136,7 @@ It is possible to use argument parser alone, without the cli mini-framework:
 
     main(Args) ->
         #{force := Force, recursive := Recursive, dir := Dir} =
-            argparse:parse(Args, cli()),
+            arg_parse:parse(Args, cli()),
         io:format("Removing ~s (force: ~s, recursive: ~s)~n",
             [Dir, Force, Recursive]).
 

--- a/doc/ARGPARSE_REF.md
+++ b/doc/ARGPARSE_REF.md
@@ -11,17 +11,17 @@ named after ```init:get_argument(progname)```. Empty command produces empty argu
 
 It's possible to override program name using **progname** option:
 
-    2> io:format(argparse:help(#{}, #{progname => "readme"})).
+    2> io:format(arg_parse:help(#{}, #{progname => "readme"})).
     usage: readme
 
 To override default optional argument prefix (**-**), use **prefixes** option:
 
-    3> argparse:parse(["+sbwt"], #{arguments => [#{name => mode, short => $s}]}, #{prefixes => "+"}).
+    3> arg_parse:parse(["+sbwt"], #{arguments => [#{name => mode, short => $s}]}, #{prefixes => "+"}).
     #{mode => "bwt"}
 
 To define a global default for arguments that are not required, use **default** option:
 
-    4> argparse:parse([], #{arguments => [#{name => mode, required => false}]}, #{default => undef}).
+    4> arg_parse:parse([], #{arguments => [#{name => mode, required => false}]}, #{default => undef}).
     #{mode => undef}
 
 When global default is not set, resulting argument map does not include keys for arguments
@@ -32,7 +32,7 @@ that are not specified in the command line and there is no locally defined defau
 Function ```validate/1``` may be used to validate command with all sub-commands
 and options without actual parsing done.
 
-    4> argparse:validate(#{arguments => [#{short => $4}]}).
+    4> arg_parse:validate(#{arguments => [#{short => $4}]}).
     ** exception error: {argparse,{invalid_option,["erl"],
         [],name,"argument must be a map, and specify 'name'"}}
 
@@ -43,7 +43,7 @@ Human-readable errors and usage information is accessible via ```help/2``` and `
 If root level command does not contain any sub-commands, parser returns plain map of
 argument names to their values:
 
-    3> argparse:parse(["value"], #{arguments => [#{name => arg}]}).
+    3> arg_parse:parse(["value"], #{arguments => [#{name => arg}]}).
     #{arg => "value"}
 
 This map contains all arguments matching command line passed, initialised with
@@ -60,7 +60,7 @@ name, and a sub-spec passed for this command:
 
     4> Cmd =  #{arguments => [#{name => arg}]}.
     #{arguments => [#{name => arg}]}
-    5> argparse:parse(["cmd", "value"], #{commands => #{"cmd" => Cmd}}).
+    5> arg_parse:parse(["cmd", "value"], #{commands => #{"cmd" => Cmd}}).
     {#{arg => "value"},{"cmd",#{arguments => [#{name => arg}]}}}
 
 ## Command specification
@@ -76,7 +76,7 @@ exporting ```cli/0``` also exports function function with arity 1, named
 after command:
 
     cli() -> #{commands => #{"run" => #{...}}}.
-    
+
     run(ArgMap) -> ....
 
 If command contains sub-commands, and handler is not present, it is an error
@@ -205,9 +205,9 @@ Argparse throws exceptions of class error, and Reason tuple:
 ```
 To get human-readable representation:
 ```erlang
-    try argparse:parse(Args, Command)
+    try arg_parse:parse(Args, Command)
     catch error:{argparse, Reason} ->
-        io:format(argparse:format_error(Reason, Command, #{}))
+        io:format(arg_parse:format_error(Reason, Command, #{}))
     end.
 ```
 

--- a/doc/CLI_REF.md
+++ b/doc/CLI_REF.md
@@ -41,7 +41,7 @@ Creating a new application exposing CLI is as simple as:
 1. Running `rebar3 new escript conf_reader`
 2. Adding `argparse` to `deps` and `escript_incl_apps` in rebar.config
 3. Add a function (`cli/0`) declaring CLI arguments
-4. Use the specification: `argparse:parse(Args, cli())`
+4. Use the specification: `arg_parse:parse(Args, cli())`
 5. Run `rebar3 escriptize` to build the application.
 
 ## Command-line interface discovery

--- a/doc/examples/conf_reader/src/conf_reader.erl
+++ b/doc/examples/conf_reader/src/conf_reader.erl
@@ -4,13 +4,13 @@
 
 main(Args) ->
     try
-        #{file := File} = Parsed = argparse:parse(Args, cli()),
+        #{file := File} = Parsed = arg_parse:parse(Args, cli()),
         {ok, Terms} = file:consult(File),
         Filtered = filter(key, Parsed, filter(app, Parsed, Terms)),
         io:format("~tp.~n", [Filtered])
     catch
-        error:{argparse, Reason} ->
-            io:format("error: ~s~n", [argparse:format_error(Reason)])
+        error:{arg_parse, Reason} ->
+            io:format("error: ~s~n", [arg_parse:format_error(Reason)])
     end.
 
 filter(ArgKey, Parsed, Terms) when is_map_key(ArgKey, Parsed) ->

--- a/doc/examples/escript/erm
+++ b/doc/examples/escript/erm
@@ -6,7 +6,7 @@
 
 main(Args) ->
     #{force := Force, recursive := Recursive, dir := Dir} =
-        argparse:parse(Args, cli()),
+        arg_parse:parse(Args, cli()),
     io:format("Removing ~s (force: ~s, recursive: ~s)~n",
         [Dir, Force, Recursive]).
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -2,7 +2,7 @@
 
    @version 1.2.4
    @author Maxim Fedorov, <maximfca@gmail.com>
-   @title argparse: A simple framework to create complex CLI.
+   @title arg_parse: A simple framework to create complex CLI.
 
    @doc
    Inspired by Python argparse.
@@ -142,7 +142,7 @@
 
        main(Args) ->
            #{force := Force, recursive := Recursive, dir := Dir} =
-               argparse:parse(Args, cli()),
+               arg_parse:parse(Args, cli()),
            io:format("Removing ~s (force: ~s, recursive: ~s)~n",
                [Dir, Force, Recursive]).
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -2,7 +2,7 @@
 
    @version 1.2.4
    @author Maxim Fedorov, <maximfca@gmail.com>
-   @title arg_parse: A simple framework to create complex CLI.
+   @title argparse: A simple framework to create complex CLI.
 
    @doc
    Inspired by Python argparse.

--- a/src/arg_parse.erl
+++ b/src/arg_parse.erl
@@ -35,6 +35,8 @@
 %%% '''
 %%% @end
 
+%%% Note: module was originally `argparse` - with OTP26 that name is in use by the
+%%% stdlib application... Hence the rename.
 -module(arg_parse).
 -author("maximfca@gmail.com").
 

--- a/src/arg_parse.erl
+++ b/src/arg_parse.erl
@@ -14,7 +14,7 @@
 %%% If root level command does not contain any sub-commands, parser returns plain map of
 %%% argument names to their values:
 %%% ```
-%%% 3> argparse:parse(["value"], #{arguments => [#{name => arg}]}).
+%%% 3> arg_parse:parse(["value"], #{arguments => [#{name => arg}]}).
 %%% #{arg => "value"}
 %%% '''
 %%% This map contains all arguments matching command line passed, initialised with
@@ -30,12 +30,12 @@
 %%% ```
 %%% 4> Cmd =  #{arguments => [#{name => arg}]}.
 %%% #{arguments => [#{name => arg}]}
-%%% 5> argparse:parse(["cmd", "value"], #{commands => #{"cmd" => Cmd}}).
+%%% 5> arg_parse:parse(["cmd", "value"], #{commands => #{"cmd" => Cmd}}).
 %%% {#{arg => "value"},{"cmd",#{arguments => [#{name => arg}]}}}
 %%% '''
 %%% @end
 
--module(argparse).
+-module(arg_parse).
 -author("maximfca@gmail.com").
 
 -export([
@@ -288,9 +288,9 @@ help(Command, Options) ->
     unicode:characters_to_list(format_help(validate(Command, Options), Options)).
 
 %% @doc Format exception reasons produced by parse/2.
-%% Exception of class error with reason {argparse, Reason} is normally
+%% Exception of class error with reason {arg_parse, Reason} is normally
 %%  raised, and format_error accepts only the Reason part, leaving
-%%  other exceptions that do not belong to argparse out.
+%%  other exceptions that do not belong to arg_parse out.
 %% @returns string, ready to be printed via io:format().
 -spec format_error(Reason :: argparse_reason()) -> string().
 format_error({invalid_command, Path, Field, Text}) ->

--- a/src/argparse.app.src
+++ b/src/argparse.app.src
@@ -1,10 +1,10 @@
 {application, argparse,
- [{description, "arg_parse: arguments parser, and cli framework"},
+ [{description, "argparse: arguments parser, and cli framework"},
   {vsn, "1.2.4"},
   {applications,
    [kernel,
     stdlib
    ]},
   {licenses, ["BSD 3-clause clear"]},
-  {links, [{"GitHub", "https://github.com/aeternity/argparse"}]}
+  {links, [{"GitHub", "https://github.com/max-au/argparse"}]}
  ]}.

--- a/src/argparse.app.src
+++ b/src/argparse.app.src
@@ -1,10 +1,10 @@
 {application, argparse,
- [{description, "argparse: arguments parser, and cli framework"},
+ [{description, "arg_parse: arguments parser, and cli framework"},
   {vsn, "1.2.4"},
   {applications,
    [kernel,
     stdlib
    ]},
   {licenses, ["BSD 3-clause clear"]},
-  {links, [{"GitHub", "https://github.com/max-au/argparse"}]}
+  {links, [{"GitHub", "https://github.com/aeternity/argparse"}]}
  ]}.


### PR DESCRIPTION
This PR is supported by the Æternity Foundation
